### PR TITLE
fs_mgr: change fsck.f2fs parameter

### DIFF
--- a/fs_mgr/fs_mgr.c
+++ b/fs_mgr/fs_mgr.c
@@ -155,10 +155,10 @@ static void check_fs(char *blk_device, char *fs_type, char *target)
     } else if (!strcmp(fs_type, "f2fs")) {
             char *f2fs_fsck_argv[] = {
                     F2FS_FSCK_BIN,
-                    "-f",
+                    "-a",
                     blk_device
             };
-        INFO("Running %s -f %s\n", F2FS_FSCK_BIN, blk_device);
+        INFO("Running %s -a %s\n", F2FS_FSCK_BIN, blk_device);
 
         ret = android_fork_execvp_ext(ARRAY_SIZE(f2fs_fsck_argv), f2fs_fsck_argv,
                                       &status, true, LOG_KLOG | LOG_FILE,


### PR DESCRIPTION
Currently, fsck.f2fs use -f to check the f2fs partition during bootup.
However, it will print lots of failed information.
I send an E-mail to f2fs maintainer, he suggest use "-a" instead of "-f".
I also check the motorola system core in github, it also use "-a".
Please refer to
https://github.com/MotorolaMobilityLLC/system-core/commit/e26ec508283b2af0f6939f81b7755690f3a961a1

Change-Id: If01b169fed2a6d1d13ca2e8a7f1ca606ac645a49