### PR TITLE
healthd: Add fast charging UI support [2/3]

### DIFF
--- a/healthd/BatteryMonitor.h
+++ b/healthd/BatteryMonitor.h
@@ -56,6 +56,7 @@ class BatteryMonitor {
     struct BatteryProperties props;
 
     int getBatteryStatus(const char* status);
+    int getBatteryChargeRate(const char* status);
     int getBatteryHealth(const char* status);
     int readFromFile(const String8& path, char* buf, size_t size);
     PowerSupplyType readPowerSupplyType(const String8& path);

--- a/healthd/healthd.cpp
+++ b/healthd/healthd.cpp
@@ -52,6 +52,7 @@ static struct healthd_config healthd_config = {
     .periodic_chores_interval_fast = DEFAULT_PERIODIC_CHORES_INTERVAL_FAST,
     .periodic_chores_interval_slow = DEFAULT_PERIODIC_CHORES_INTERVAL_SLOW,
     .batteryStatusPath = String8(String8::kEmptyString),
+    .batteryChargeRatePath = String8(String8::kEmptyString),
     .batteryHealthPath = String8(String8::kEmptyString),
     .batteryPresentPath = String8(String8::kEmptyString),
     .batteryCapacityPath = String8(String8::kEmptyString),
@@ -75,6 +76,8 @@ static struct healthd_config healthd_config = {
     .dockBatteryCurrentAvgPath = String8(String8::kEmptyString),
     .dockBatteryChargeCounterPath = String8(String8::kEmptyString),
     .dockEnergyCounter = NULL,
+    .mapBatteryStatusString = NULL,
+    .mapChargeRateString = NULL,
 };
 
 static int eventct;

--- a/healthd/healthd.h
+++ b/healthd/healthd.h
@@ -74,6 +74,7 @@ struct healthd_config {
     int periodic_chores_interval_slow;
 
     android::String8 batteryStatusPath;
+    android::String8 batteryChargeRatePath;
     android::String8 batteryHealthPath;
     android::String8 batteryPresentPath;
     android::String8 batteryCapacityPath;
@@ -100,6 +101,16 @@ struct healthd_config {
     android::String8 dockBatteryChargeCounterPath;
 
     int (*dockEnergyCounter)(int64_t *);
+
+    /* Provide extensions for the string to int mappings.  Returning a value
+     * >= 0 will use that value, a negative number is an error code and
+     * the special value HEALTHD_MAP_CONTINUE_SEARCH will fall back to the
+     * built-in mapping.
+     */
+    #define HEALTHD_MAP_CONTINUE_SEARCH INT_MAX
+
+    int (*mapBatteryStatusString)(const char *status);
+    int (*mapChargeRateString)(const char *charge_rate);
 };
 
 // Global helper functions


### PR DESCRIPTION
Exposes the charge_type battery property.

At the same time provide libhealthd hooks to customize the
processing of the status and charge_type strings.  These
strings are not standardized at this time when it comes to
fast charging.  For example,

* Asus uses status = "Quick charging" or status = "Not quick charging"
  when plugged into a fast charger to indicate that it is charging
  on a fast charger.

* Motorola uses charge_type sanely.

* Oppo uses a completely different boolean property.

and therefore we do not offer a default parsing of the charge
type and require that users add a libhealthd that defines the path
to read and the function to interpret the result of reading that
file.

Change-Id: Ib99e408ddc635a9029a8ad6a38ffb1529c3f9a01

Patchset: 6
http://review.cyanogenmod.org/#/c/109365/